### PR TITLE
Remove unused "Home" link from footer component

### DIFF
--- a/components/common/footer.tsx
+++ b/components/common/footer.tsx
@@ -176,19 +176,6 @@ export default function Footer() {
                     </Heading>
                     <VStack align={"left"}>
                       <ChakraLink asChild>
-                        <NextLink href="/">
-                          <Center>
-                            <Icon
-                              name="AngleRight"
-                              size={6}
-                              color={"teal.focusRing"}
-                            />
-                            <Text textStyle={"md"}>Home</Text>
-                          </Center>
-                        </NextLink>
-                      </ChakraLink>
-
-                      <ChakraLink asChild>
                         <NextLink href="/about-us">
                           <Center>
                             <Icon


### PR DESCRIPTION
This pull request makes a small change to the `Footer` component by removing the "Home" link from the list of Quick Links.

- Removed the "Home" link from the Quick Links section in the `Footer` component (`components/common/footer.tsx`).